### PR TITLE
ALPAO DM97

### DIFF
--- a/zygo_automation/__init__.py
+++ b/zygo_automation/__init__.py
@@ -1,1 +1,1 @@
-from . import analysis, automation, bmc, irisao, zygo, pylon
+from . import alpao, analysis, automation, bmc, irisao, pylon, zygo

--- a/zygo_automation/alpao.py
+++ b/zygo_automation/alpao.py
@@ -82,7 +82,6 @@ def map_vector_to_square(vector):
     array = np.zeros((11,11))
     circmask = draw.circle(5,5,5.5,(11,11))
     array[circmask] = vector
-    array = array
     return array
 
 def map_square_to_vector(array):
@@ -101,7 +100,6 @@ def actuator_locations_array():
     square = np.zeros((11,11))
     circmask = draw.circle(5,5,5.5,(11,11))
     square[circmask] = np.arange(1,98)
-    square = square
     return square
 
 def generate_zernike_modes(nterms=15,to_vector=True):

--- a/zygo_automation/alpao.py
+++ b/zygo_automation/alpao.py
@@ -82,7 +82,7 @@ def map_vector_to_square(vector):
     array = np.zeros((11,11))
     circmask = draw.circle(5,5,5.5,(11,11))
     array[circmask] = vector
-    array = array[:,::-1].T
+    array = array
     return array
 
 def map_square_to_vector(array):
@@ -94,14 +94,14 @@ def map_square_to_vector(array):
     ALPAO SDK)
     '''
     circmask = draw.circle(5,5,5.5,(11,11))
-    return array[::-1,:].T[circmask]
+    return array[circmask]
 
 def actuator_locations_array():
     #Actuator locations defined on 11x11 array
     square = np.zeros((11,11))
     circmask = draw.circle(5,5,5.5,(11,11))
     square[circmask] = np.arange(1,98)
-    square = square[:,::-1].T
+    square = square
     return square
 
 def generate_zernike_modes(nterms=15,to_vector=True):

--- a/zygo_automation/alpao.py
+++ b/zygo_automation/alpao.py
@@ -16,6 +16,8 @@ import numpy as np
 from skimage import draw
 import poppy
 
+from astropy.io import fits
+
 def apply_command(data, serial):
     '''
     Apply a command to an ALPAO DM via shared
@@ -41,6 +43,26 @@ def apply_command(data, serial):
     img.link(serial)
     #write to shared memory
     img.write(data.astype(np.float64))
+
+def command_to_fits(data, filename, overwrite=False):
+    '''
+    Save a command to fits file.
+
+    Parameters:
+        data : nd array
+            97 x 1 nd array of type float64
+        filename : str
+            File name to save fits file to.
+        overwrite : bool, opt.
+            Overwrite file if it already exists?
+    Returns:
+        nothing
+    '''
+    #add empty dimension to 1D arrays
+    if np.ndim(data) == 1:
+        data = np.expand_dims(data,1)
+    hdu = fits.PrimaryHDU(data.astype(np.float64))
+    hdu.writeto(filename, overwrite=overwrite)
 
 def set_single_actuator(n, value):
     '''

--- a/zygo_automation/alpao.py
+++ b/zygo_automation/alpao.py
@@ -35,6 +35,10 @@ def apply_command(data, serial):
         nothing
     '''
 
+    # check that max/min aren't violated
+    if np.any(np.abs(data) > 1):
+        raise ValueError("DM97 inputs must be between -1 and +1.")
+
     #add empty dimension to 1D arrays
     if np.ndim(data) == 1:
         data = np.expand_dims(data,1)

--- a/zygo_automation/alpao.py
+++ b/zygo_automation/alpao.py
@@ -42,7 +42,7 @@ def apply_command(data, serial):
     img = shmio.Image()
     img.link(serial)
     #write to shared memory
-    img.write(data)
+    img.write(data.astype(np.float64))
 
 def release_mirror(serial):
     log.warning("This doesn't do anything yet! The DM is NOT released.")

--- a/zygo_automation/alpao.py
+++ b/zygo_automation/alpao.py
@@ -33,11 +33,6 @@ def apply_command(data, serial):
     Returns:
         nothing
     '''
-
-    # check that max/min aren't violated
-    if np.any(np.abs(data) > 1):
-        raise ValueError("DM97 inputs must be between -1 and +1.")
-
     #add empty dimension to 1D arrays
     if np.ndim(data) == 1:
         data = np.expand_dims(data,1)
@@ -56,13 +51,11 @@ def set_single_actuator(n, value):
         n : int
             Actuator number. See actuator_locations_array
         value : float
-            Fractional value to place on the DM. Must be
-            between -1 and +1.
+            Displacement to place on the DM, given in microns.
     Returns:
         inputs : nd array
             97 x 1 array of zeros except for poked actuator
     '''
-    if not np.abs(value) <= 1: raise ValueError("DM97 inputs must be between -1 and +1.")
     inputs = np.zeros((97,), dtype=np.float64)
     inputs[n] = value
     return inputs
@@ -76,8 +69,8 @@ def set_row_column(idx, value, dim):
         idx : int
             Column number. See actuator_locations_array
         value : float
-            Fractional value to place on the DM. Must be
-            between -1 and +1.
+            Displacement value to place on the DM, given
+            in microns.
         dim : int
             0 or 1. X or Y axis.
     Returns:

--- a/zygo_automation/alpao.py
+++ b/zygo_automation/alpao.py
@@ -22,6 +22,10 @@ def apply_command(data, serial):
     Apply a command to an ALPAO DM via shared
     memory image.
 
+    This assumes you already have the ALPAO control
+    loop running and waiting for share memory images
+    at <serial>.
+
     Parameters:
         data : nd array
             97 x 1 nd array of type float64

--- a/zygo_automation/alpao.py
+++ b/zygo_automation/alpao.py
@@ -1,0 +1,122 @@
+'''
+Functions for commanding ALPAO DM97 via
+shared memory images, as implemented in milk.
+
+'''
+
+import logging
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+try:
+    import pyImageStreamIO as shmio #shared memory io
+except ImportError:
+    log.warning('Could not load pyImageStreamIO package! You will not be able to command the ALPAO.')
+
+import numpy as np
+from skimage import draw
+import poppy
+
+def apply_command(data, serial):
+    '''
+    Apply a command to an ALPAO DM via shared
+    memory image.
+
+    Parameters:
+        data : nd array
+            97 x 1 nd array of type float64
+        serial : str
+            DM serial number. Example: "BAX150"
+    Returns:
+        nothing
+    '''
+
+    #add empty dimension to 1D arrays
+    if np.ndim(data) == 1:
+        data = np.expand_dims(data,1)
+    #connect to shared memory image
+    img = shmio.Image()
+    img.link(serial)
+    #write to shared memory
+    img.write(data)
+
+def release_mirror(serial):
+    log.warning("This doesn't do anything yet! The DM is NOT released.")
+    pass
+
+def set_single_actuator(n, value):
+    if not np.abs(value) <= 1: raise ValueError("DM97 inputs must be between -1 and +1.")
+    inputs = np.zeros((97,), dtype=np.float64)
+    inputs[n] = value
+    return inputs
+
+def set_row_column(idx, value, dim):
+    array = np.zeros((11,11))
+    if dim == 0:
+        array[idx,:] = value
+    elif dim == 1:
+        array[:,idx] = value
+    return map_square_to_vector(array)
+
+def influence_function_loop(value):
+    allinputs = []
+    for n in range(97):
+        allinputs.append(set_single_actuator(n, value))
+    return allinputs
+
+def map_vector_to_square(vector):
+    '''
+    Given the DM data values in a vector
+    ordered by actuator number, embed the
+    data in a square array (primarily for 
+    visualization purposes).
+    '''
+    array = np.zeros((11,11))
+    circmask = draw.circle(5,5,5.5,(11,11))
+    array[circmask] = vector
+    array = array[:,::-1].T
+    return array
+
+def map_square_to_vector(array):
+    '''
+    Given the dm data values embedded
+    in a square (11x11) array, pull out
+    the actuator values in an properly ordered
+    vector (that could be passed directly to the 
+    ALPAO SDK)
+    '''
+    circmask = draw.circle(5,5,5.5,(11,11))
+    return array[::-1,:].T[circmask]
+
+def actuator_locations_array():
+    #Actuator locations defined on 11x11 array
+    square = np.zeros((11,11))
+    circmask = draw.circle(5,5,5.5,(11,11))
+    square[circmask] = np.arange(1,98)
+    square = square[:,::-1].T
+    return square
+
+def generate_zernike_modes(nterms=15,to_vector=True):
+    '''
+    Generate Zernike modes orthonormalized on actuator
+    array.
+
+    Parameters:
+        nterms: int
+            Number of zernike modes
+        to_vector:
+            Return modes as vectors in 
+            actuator order
+    Returns:
+        zbasis: array of 1D or 2D arrays of zernike modes
+    '''
+    aperture = np.zeros((11,11))
+    circmask = draw.circle(5,5,5.5,(11,11))
+    aperture[circmask] = 1
+
+    zbasis = poppy.zernike.arbitrary_basis(aperture,nterms=nterms,outside=0)
+
+    if to_vector:
+        return [map_square_to_vector(z) for z in zbasis]
+    else:
+        return zbasis

--- a/zygo_automation/analysis.py
+++ b/zygo_automation/analysis.py
@@ -38,3 +38,36 @@ def squarify(a, pad_value=0):
     else:# shape[1] > shape[0]:
         padding = ((0,0),(to_add//2, to_add//2))
     return np.pad(a, padding, mode='constant', constant_values=0. )
+
+def get_klip_basis(R, cutoff):
+    '''
+    Succinct KLIP implementation courtesy of N. Zimmerman
+    '''
+    w, V = np.linalg.eig(np.dot(R, np.transpose(R)))
+    sort_ind = np.argsort(w)[::-1] #indices of eigenvals sorted in descending order
+    sv = np.sqrt(w[sort_ind]).reshape(-1,1) #column of ranked singular values
+    Z = np.dot(1./sv*np.transpose(V[:, sort_ind]), R)
+    return Z[0:cutoff, :], sv
+
+def klip_projection(target,reflib,truncation=10):
+    refflat = reflib.reshape(reflib.shape[0],-1)
+    targflat = target.flatten()
+    Z, _ = get_klip_basis(refflat,truncation)
+    proj = targflat.dot(Z.T)
+    return Z.T.dot(proj).reshape(target.shape)
+
+def get_influence_pseudo_inverse(influence_cube):
+    '''
+    Given Z x Y x X cube, return the Z x (X * Y)
+    flatten IF cube and its pseudo-inverse
+    '''
+    shape = influence_cube.shape
+    F = np.asarray(influence_cube).reshape(shape[0], -1).T
+    Finv = np.linalg.pinv(F)
+    return F, Finv
+
+def get_strokemap(surface, Finv):
+    return np.dot(Finv,surface.flatten())
+
+def predict_stroke(strokemap, F):
+    return np.dot(strokemap,F.T)

--- a/zygo_automation/automation.py
+++ b/zygo_automation/automation.py
@@ -290,8 +290,6 @@ class BMCMonitor(FileMonitor):
         load_channel(newdata, 0)
 
         # Write out empty file to tell Zygo the DM is ready.
-        # Force a new file name with the iterator just to
-        # avoid conflicts with past files.
         open(os.path.join(os.path.dirname(self.file), 'dm_ready'), 'w').close()
 
 class ALPAOMonitor(FileMonitor):
@@ -326,8 +324,6 @@ class ALPAOMonitor(FileMonitor):
         alpao.apply_command(fits.open(newdata)[0].data, self.serial)
 
         # Write out empty file to tell Zygo the DM is ready.
-        # Force a new file name with the iterator just to
-        # avoid conflicts with past files.
         open(os.path.join(os.path.dirname(self.file), 'dm_ready'), 'w').close()
 
 class IrisAOMonitor(FileMonitor):
@@ -359,8 +355,6 @@ class IrisAOMonitor(FileMonitor):
         apply_ptt_command(newdata)
 
         # Write out empty file to tell Zygo the DM is ready.
-        # Force a new file name with the iterator just to
-        # avoid conflicts with past files.
         open(os.path.join(os.path.dirname(self.file), 'dm_ready'), 'w').close()
 
 class BaslerMonitor(FileMonitor):

--- a/zygo_automation/automation.py
+++ b/zygo_automation/automation.py
@@ -4,6 +4,7 @@ from time import sleep
 
 import h5py
 import numpy as np
+from astropy.io import fits
 
 from .zygo import capture_frame, read_many_raw_datx
 from .bmc import load_channel, write_fits
@@ -321,7 +322,7 @@ class ALPAOMonitor(FileMonitor):
         '''
         # Load image from FITS file onto DM channel 0
         log.info('Setting DM from new image file {}'.format(newdata))
-        alpao.apply_command(fits.read(newdata)[0].data, serial)
+        alpao.apply_command(fits.open(newdata)[0].data, serial)
 
         # Write out empty file to tell Zygo the DM is ready.
         # Force a new file name with the iterator just to

--- a/zygo_automation/automation.py
+++ b/zygo_automation/automation.py
@@ -35,7 +35,7 @@ def zygo_dm_run(dm_inputs, network_path, outname, dmtype, delay=None, consolidat
             cross-machine communication will take place.
             Both machines must have read/write privileges.
         dmtype : str
-            'bmc' or 'irisao'. This determines whether
+            'bmc', 'irisao', or 'alpao'. This determines whether
             the dm_inputs are written to .fits or .txt.
         outname : str
             Directory to write results out to. Directory
@@ -63,7 +63,7 @@ def zygo_dm_run(dm_inputs, network_path, outname, dmtype, delay=None, consolidat
     Returns: nothing
 
     '''
-    if dmtype.upper() not in ['BMC','IRISAO']:
+    if dmtype.upper() not in ['BMC','IRISAO','ALPAO']:
         raise ValueError('dmtype not recognized. Must be either "BMC" or "IRISAO".')
 
     if not (dry_run or clobber):
@@ -75,7 +75,7 @@ def zygo_dm_run(dm_inputs, network_path, outname, dmtype, delay=None, consolidat
 
     for idx, inputs in enumerate(dm_inputs):
 
-        if dmtype.upper() == 'BMC':
+        if (dmtype.upper() == 'BMC') or (dmtype.upper() == 'ALPAO'):
             #Remove any old inputs if they exist
             old_files = glob.glob(os.path.join(network_path,'dm_input*.fits'))
             for old_file in old_files:
@@ -313,6 +313,7 @@ class ALPAOMonitor(FileMonitor):
                 ALPAO DM97 serial number. Probably "BAX150"
         '''
         super().__init__(os.path.join(path, input_file))
+        self.serial = serial
 
     def on_new_data(self, newdata):
         '''
@@ -322,7 +323,7 @@ class ALPAOMonitor(FileMonitor):
         '''
         # Load image from FITS file onto DM channel 0
         log.info('Setting DM from new image file {}'.format(newdata))
-        alpao.apply_command(fits.open(newdata)[0].data, serial)
+        alpao.apply_command(fits.open(newdata)[0].data, self.serial)
 
         # Write out empty file to tell Zygo the DM is ready.
         # Force a new file name with the iterator just to


### PR DESCRIPTION
This PR introduces ALPAO functionality to control the DM97 in Python via [pyImageStreamIO](https://github.com/milk-org/pyImageStreamIO) and my [ALPAO C interface](https://github.com/magao-x/ALPAO-interface).

So far, includes functions to:
* Apply commands via shared memory images
* Create inputs of single actuator pokes, column/row pokes, zernike modes
* Create inputs for influence function calibration
* Map vector inputs to 2D array for visualization purposes (and vice versa)

Still needed:
* `FileMonitor` subclass to complete the Zygo-ALPAO loop